### PR TITLE
fix(security): prevent 2FA bypass via server-side verification timestamp

### DIFF
--- a/prisma/migrations/20260326000000_add_last_two_factor_verified_at/migration.sql
+++ b/prisma/migrations/20260326000000_add_last_two_factor_verified_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Admin" ADD COLUMN "lastTwoFactorVerifiedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "WhitelistUser" ADD COLUMN "lastTwoFactorVerifiedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,29 +160,31 @@ enum ActivityType {
 
 // Private Instance Mode (Issue #4)
 model Admin {
-  id                   String   @id @default(cuid())
-  email                String   @unique
-  password             String   // bcrypt hashed
-  name                 String?
-  mustChangePassword   Boolean  @default(false)
-  twoFactorEnabled     Boolean  @default(false)
-  twoFactorSecret      String?  // Encrypted TOTP secret
-  twoFactorBackupCodes String?  // JSON array of encrypted backup codes
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  id                        String    @id @default(cuid())
+  email                     String    @unique
+  password                  String    // bcrypt hashed
+  name                      String?
+  mustChangePassword        Boolean   @default(false)
+  twoFactorEnabled          Boolean   @default(false)
+  twoFactorSecret           String?   // Encrypted TOTP secret
+  twoFactorBackupCodes      String?   // JSON array of encrypted backup codes
+  lastTwoFactorVerifiedAt   DateTime? // Server-side 2FA verification timestamp (Issue #123)
+  createdAt                 DateTime  @default(now())
+  updatedAt                 DateTime  @updatedAt
 }
 
 model WhitelistUser {
-  id                   String   @id @default(cuid())
-  email                String   @unique
-  password             String?  // bcrypt hashed (null until first login setup)
-  name                 String?
-  mustChangePassword   Boolean  @default(true) // Must change on first login
-  twoFactorEnabled     Boolean  @default(false)
-  twoFactorSecret      String?  // Encrypted TOTP secret
-  twoFactorBackupCodes String?  // JSON array of encrypted backup codes
-  addedById            String   // Admin who added this user
-  createdAt            DateTime @default(now())
+  id                        String    @id @default(cuid())
+  email                     String    @unique
+  password                  String?   // bcrypt hashed (null until first login setup)
+  name                      String?
+  mustChangePassword        Boolean   @default(true) // Must change on first login
+  twoFactorEnabled          Boolean   @default(false)
+  twoFactorSecret           String?   // Encrypted TOTP secret
+  twoFactorBackupCodes      String?   // JSON array of encrypted backup codes
+  lastTwoFactorVerifiedAt   DateTime? // Server-side 2FA verification timestamp (Issue #123)
+  addedById                 String    // Admin who added this user
+  createdAt                 DateTime  @default(now())
 }
 
 // Rate Limiting for distributed environments (Issue #41)

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -191,6 +191,21 @@ export async function POST(request: Request) {
     // Clear rate limit attempts on successful verification
     clearAttempts(rateLimitKey)
 
+    // Record server-side 2FA verification timestamp (Issue #123)
+    // This prevents client-side bypass of twoFactorVerified flag
+    const now = new Date()
+    if (isAdmin) {
+      await prisma.admin.update({
+        where: { id: user.id },
+        data: { lastTwoFactorVerifiedAt: now },
+      })
+    } else {
+      await prisma.whitelistUser.update({
+        where: { id: user.id },
+        data: { lastTwoFactorVerifiedAt: now },
+      })
+    }
+
     // 6. Return { success: true, verified: true } on success
     return NextResponse.json({
       success: true,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -139,38 +139,52 @@ const authConfig: NextAuthConfig = {
       if (trigger === 'update' && token.sub) {
         const admin = await prisma.admin.findUnique({
           where: { id: token.sub },
-          select: { mustChangePassword: true, twoFactorEnabled: true },
+          select: {
+            mustChangePassword: true,
+            twoFactorEnabled: true,
+            lastTwoFactorVerifiedAt: true,
+          },
         })
         if (admin) {
           ;(token as Record<string, unknown>).mustChangePassword =
             admin.mustChangePassword
           ;(token as Record<string, unknown>).twoFactorEnabled =
             admin.twoFactorEnabled ?? false
-          // Clear requiresTwoFactor after 2FA verification (triggered by session update)
+          // Clear requiresTwoFactor only if server-side 2FA verification is recent (Issue #123)
+          // Never trust client-sent twoFactorVerified flag alone
           if (
             updateData &&
             typeof updateData === 'object' &&
             'twoFactorVerified' in updateData &&
-            updateData.twoFactorVerified === true
+            updateData.twoFactorVerified === true &&
+            admin.lastTwoFactorVerifiedAt &&
+            Date.now() - admin.lastTwoFactorVerifiedAt.getTime() < 5 * 60 * 1000
           ) {
             ;(token as Record<string, unknown>).requiresTwoFactor = false
           }
         } else {
           const whitelistUser = await prisma.whitelistUser.findUnique({
             where: { id: token.sub },
-            select: { mustChangePassword: true, twoFactorEnabled: true },
+            select: {
+              mustChangePassword: true,
+              twoFactorEnabled: true,
+              lastTwoFactorVerifiedAt: true,
+            },
           })
           if (whitelistUser) {
             ;(token as Record<string, unknown>).mustChangePassword =
               whitelistUser.mustChangePassword
             ;(token as Record<string, unknown>).twoFactorEnabled =
               whitelistUser.twoFactorEnabled ?? false
-            // Clear requiresTwoFactor after 2FA verification (triggered by session update)
+            // Clear requiresTwoFactor only if server-side 2FA verification is recent (Issue #123)
             if (
               updateData &&
               typeof updateData === 'object' &&
               'twoFactorVerified' in updateData &&
-              updateData.twoFactorVerified === true
+              updateData.twoFactorVerified === true &&
+              whitelistUser.lastTwoFactorVerifiedAt &&
+              Date.now() - whitelistUser.lastTwoFactorVerifiedAt.getTime() <
+                5 * 60 * 1000
             ) {
               ;(token as Record<string, unknown>).requiresTwoFactor = false
             }


### PR DESCRIPTION
## Summary
- 2FA verify API成功時にDBの`lastTwoFactorVerifiedAt`にタイムスタンプを記録
- JWT callbackで`twoFactorVerified`フラグを受け取った際、DBのタイムスタンプが直近5分以内であることを確認
- クライアント側からの`twoFactorVerified`改ざんによる2FAバイパスを防止
- Admin/WhitelistUser両テーブルに`lastTwoFactorVerifiedAt`カラム追加（nullable、後方互換）

## Test plan
- [x] 全テスト合格 (275 passed)
- [x] マイグレーションはnullable追加のみ（既存データに影響なし）

Closes #123