### PR TITLE
fix(security): sanitize error logging to prevent information leakage

### DIFF
--- a/src/app/groups/[groupId]/edit/delete-group-button.tsx
+++ b/src/app/groups/[groupId]/edit/delete-group-button.tsx
@@ -55,7 +55,10 @@ export function DeleteGroupButton() {
       await utils.groups.invalidate()
       router.push('/groups')
     } catch (error) {
-      console.error('Failed to delete group:', error)
+      console.error(
+        'Failed to delete group:',
+        error instanceof Error ? error.message : 'Unknown error',
+      )
       setIsDeleting(false)
     }
   }

--- a/src/app/groups/[groupId]/group-deleted-screen.tsx
+++ b/src/app/groups/[groupId]/group-deleted-screen.tsx
@@ -78,7 +78,10 @@ export function GroupDeletedScreen({
       // Force a full page reload to show restored group
       window.location.reload()
     } catch (error) {
-      console.error('Failed to restore group:', error)
+      console.error(
+        'Failed to restore group:',
+        error instanceof Error ? error.message : 'Unknown error',
+      )
       setIsRestoring(false)
     }
   }
@@ -93,7 +96,10 @@ export function GroupDeletedScreen({
       removeSessionKey(`${SESSION_PWD_KEY_PREFIX}${groupId}`)
       router.push('/groups')
     } catch (error) {
-      console.error('Failed to permanently delete group:', error)
+      console.error(
+        'Failed to permanently delete group:',
+        error instanceof Error ? error.message : 'Unknown error',
+      )
       setIsPermanentlyDeleting(false)
     }
   }

--- a/src/lib/hooks/useBalances.ts
+++ b/src/lib/hooks/useBalances.ts
@@ -81,7 +81,7 @@ export function useBalances(groupId: string) {
         // Issue #80: Don't fall back to encrypted data - it causes wrong balance calculations
         console.error(
           'Failed to decrypt expenses for balance calculation:',
-          error,
+          error instanceof Error ? error.message : 'Unknown error',
         )
         if (isMounted) {
           setDecryptedExpenses([]) // Use empty array, not encrypted data


### PR DESCRIPTION
## Summary
- `console.error(error)`をerrorオブジェクト全体ではなく`error.message`のみ出力に変更
- delete-group-button.tsx, group-deleted-screen.tsx, useBalances.tsの4箇所を修正

## Test plan
- [x] 全テスト合格 (275 passed)

Closes #124