### PR TITLE
feat(security): add security headers (X-Frame-Options, X-Content-Type-Options)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const remotePatterns = []
 // S3 Storage
 if (process.env.S3_UPLOAD_ENDPOINT) {
   // custom endpoint for providers other than AWS
-  const url = new URL(process.env.S3_UPLOAD_ENDPOINT);
+  const url = new URL(process.env.S3_UPLOAD_ENDPOINT)
   remotePatterns.push({
     hostname: url.hostname,
   })
@@ -25,14 +25,40 @@ if (process.env.S3_UPLOAD_ENDPOINT) {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns
+    remotePatterns,
   },
   // Required to run in a codespace (see https://github.com/vercel/next.js/issues/58019)
   experimental: {
     serverActions: {
-        allowedOrigins: ['localhost:3000'],
+      allowedOrigins: ['localhost:3000'],
     },
-},
+  },
+  // Security headers (Issue #125)
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default withNextIntl(nextConfig)


### PR DESCRIPTION
## Summary
next.config.mjsにセキュリティヘッダーを追加:
- `X-Frame-Options: DENY` — クリックジャッキング防止
- `X-Content-Type-Options: nosniff` — MIMEタイプスニッフィング防止
- `Referrer-Policy: strict-origin-when-cross-origin` — リファラー制御
- `Permissions-Policy` — 不要なブラウザAPIを無効化

CSPは追加していない（Next.jsのinline scriptやWeb Crypto APIとの互換性を慎重に検証する必要があるため、別Issueで対応推奨）

## Test plan
- [x] 全テスト合格 (275 passed)

Closes #125